### PR TITLE
Rename repo to docs.luanti.org

### DIFF
--- a/.vscode/dev.code-snippets
+++ b/.vscode/dev.code-snippets
@@ -1,5 +1,5 @@
 {
-  // Place your dev.luanti.org workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // Place your docs.luanti.org workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
   // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
   // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
   // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See [About](content/about/_index.md) for more information
   - `start`: Builds and serves the site at http://localhost:1313 with Hugo.
   - `test:a11y`: Builds and serves the site, then uses Playwright and axe to test accessibility
   - `test:a11y:tests`: Not meant for independent use, only as part of `test:a11y`
-  - `test:links`: Tests validity of all links in the site. WIP, ref [#177](https://github.com/luanti-org/dev.luanti.org/issues/177)
-  - `test:spelling`: Reports all apparent spelling errors. WIP, ref [#83](https://github.com/luanti-org/dev.luanti.org/issues/83) for details.
+  - `test:links`: Tests validity of all links in the site. WIP, ref [#177](https://github.com/luanti-org/docs.luanti.org/issues/177)
+  - `test:spelling`: Reports all apparent spelling errors. WIP, ref [#83](https://github.com/luanti-org/docs.luanti.org/issues/83) for details.
 - dependencies
   - `hugo-extended`: Static site generator that turns Markdown and shortcodes into HTML
 - devDependencies

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -9,7 +9,7 @@ aliases:
 
 Luanti is a free and open-source voxel game engine with its own [distribution platform](/about/contentdb) and [client](/about/luanti). Players, creators, server hosts, and engine developers can find more information here about how to get started with Luanti.
 
-This site is created using [Hugo](https://gohugo.io/), with theme [Hugo Book](https://themes.gohugo.io/themes/hugo-book/). The site's source content can be found [on GitHub](https://github.com/luanti-org/dev.luanti.org/tree/master/content), and we welcome contributions from everyone. To contribute, see [Contributing to Docs](/about/contributing-to-docs).
+This site is created using [Hugo](https://gohugo.io/), with theme [Hugo Book](https://themes.gohugo.io/themes/hugo-book/). The site's source content can be found [on GitHub](https://github.com/luanti-org/docs.luanti.org/tree/master/content), and we welcome contributions from everyone. To contribute, see [Contributing to Docs](/about/contributing-to-docs).
 
 ## Getting Started
 
@@ -30,4 +30,4 @@ Documentation will cover:
 * Engine reference and internal structures
 * Server and platform (player-facing) usage and guides
 
-This project began in December 2024. Our roadmap can be found at [GitHub issue #113: Roadmap](https://github.com/luanti-org/dev.luanti.org/issues/113).
+This project began in December 2024. Our roadmap can be found at [GitHub issue #113: Roadmap](https://github.com/luanti-org/docs.luanti.org/issues/113).

--- a/content/about/contributing-to-docs.md
+++ b/content/about/contributing-to-docs.md
@@ -20,7 +20,7 @@ Luanti Documentation is written in Markdown and transformed into HTML by [Hugo](
 When cloning the repository you need to clone it recursively so that the theme submodule gets included:
 
 ```bash
-git clone --recursive https://github.com/luanti-org/dev.luanti.org
+git clone --recursive https://github.com/luanti-org/docs.luanti.org
 ```
 
 If you have already cloned, you can fetch the submodules as such:
@@ -32,7 +32,7 @@ git submodule update --remote
 
 This project uses [Hugo](https://gohugo.io/) to build the site and various Node packages to test it.
 
-You can install Hugo locally as a [Node.js](https://nodejs.org) package for convenience. Node is also used for further testing scripts, like spell-checking and a11y. These scripts are described in [`package.json`](https://github.com/luanti-org/dev.luanti.org/blob/master/package.json) and [`readme.md`](https://github.com/luanti-org/dev.luanti.org/blob/master/README.md).
+You can install Hugo locally as a [Node.js](https://nodejs.org) package for convenience. Node is also used for further testing scripts, like spell-checking and a11y. These scripts are described in [`package.json`](https://github.com/luanti-org/docs.luanti.org/blob/master/package.json) and [`readme.md`](https://github.com/luanti-org/docs.luanti.org/blob/master/README.md).
 
 To install and run via Node:
 
@@ -87,7 +87,7 @@ Changes are reviewed via the common "fork and pull request" approach. If you're 
   - In the left vertical menu, select the source control option
   - Enter a message about your changes and click `commit and push`
 - Local-based (terminal commands for example, use GUI client if you wish)
-  - Clone the repo `git clone https://github.com/YOURUSERNAME/dev.luanti.org`
+  - Clone the repo `git clone https://github.com/YOURUSERNAME/docs.luanti.org`
   - Make a branch `git checkout your_branch_name`
   - Make edits with the tools of your choosing
   - Add, commit, and push the changes: `git add -A && git commit -m "your commit message here" && git push`

--- a/content/for-creators/creating-texture-packs.md
+++ b/content/for-creators/creating-texture-packs.md
@@ -167,7 +167,7 @@ Your file structure should now appear as:
 
 Linux:
 
-Hopefully if you're using Linux you'll know how to do something similar. Otherwise please [open an issue with the docs team](https://github.com/luanti-org/dev.luanti.org/issues/new) and we'll update this section :)
+Hopefully if you're using Linux you'll know how to do something similar. Otherwise please [open an issue with the docs team](https://github.com/luanti-org/docs.luanti.org/issues/new) and we'll update this section :)
 
 ### Special Textures
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,5 +7,5 @@ enableGitInfo = true
 [params]
     BookTheme = 'auto'
     BookSection = '*'
-    BookRepo = 'https://github.com/luanti-org/dev.luanti.org'
+    BookRepo = 'https://github.com/luanti-org/docs.luanti.org'
     BookEditPath = 'edit/master'


### PR DESCRIPTION
All `dev.luanti.org` references were to the GH repo, not the site itself.