### PR TITLE
Increase nav button size

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -11,9 +11,9 @@
 
 aside nav ul {
   a {
-    line-height: 2;
+    line-height: 2; // increase clickable area
   }
   li {
-    margin: 0;
+    margin: 0; // HB adds margin, we increase line-height instead
   }
 }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,8 +1,10 @@
+// For compatibility with our Hugo Book (HB) theme, we need SCSS
+// However, please use vanilla CSS for simplicity in case we port to a simpler theme :)
+
 .container {
-  max-width: 90rem;
+  max-width: 90rem; // HB default is 80rem
 }
 
 .markdown img {
-  /* Circumvent SCSS min function, we need the browser's one */
-  max-width: #{"min(100%, 32rem)"};
+  max-width: calc(min(100%, 32rem)); // HB default is 100%
 }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -8,3 +8,12 @@
 .markdown img {
   max-width: calc(min(100%, 32rem)); // HB default is 100%
 }
+
+aside nav ul {
+  a {
+    line-height: 2;
+  }
+  li {
+    margin: 0;
+  }
+}

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -15,5 +15,8 @@ aside nav ul {
   }
   li {
     margin: 0; // HB adds margin, we increase line-height instead
+    label {
+      align-items: center; // expand/collapse icon needs to be centered now
+    }
   }
 }

--- a/content/about/contributing-to-docs.md
+++ b/content/about/contributing-to-docs.md
@@ -13,7 +13,7 @@ aliases:
 
 # Contributing to Docs
 
-Luanti Documentation is written in Markdown and transformed into HTML by [Hugo](https://gohugo.io), a free and open-source static site generator. The source code is currently hosted on GitHub and deployed with GitHub Actions.
+Luanti Documentation is written in Markdown and transformed into HTML by [Hugo](https://gohugo.io), a free and open-source static site generator. The source code is currently hosted on GitHub and deployed with GitHub Actions. The look and feel of the site is primarily driven by the Hugo Book (HB) theme, with changes applied as described in [HB's readme](https://github.com/alex-shpak/hugo-book#hugo-book-theme).
 
 ## Local Development
 
@@ -121,7 +121,7 @@ If you move or rename a Markdown file, add an [`aliases`](https://gohugo.io/cont
 - Use webp images instead of jpg, png, or others
 - Add a [language](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) to code blocks
 
-### Merge policies
+### Merge Policies
 
 Please announce changes (in optional minutes) in the #luanti-docs IRC/Discord/Matrix channel
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@playwright/test": "^1.49.1",
         "cspell": "^8.17.1",
         "linkinator": "^6.1.2",
-        "prettier": "^3.5.2",
+        "prettier": "3.5.2",
         "sort-package-json": "^2.14.0",
         "start-server-and-test": "^2.0.10"
       }


### PR DESCRIPTION
Works on #66 

Previous size was 16px high with 14px of margin on either side. New size is 28px high with 0px of margin

Current | Proposed
--|--
![image](https://github.com/user-attachments/assets/7b5d9183-6fa2-4163-8dd8-099586b51db9) | ![image](https://github.com/user-attachments/assets/c4881aeb-eac3-4775-b8ec-6ac62c429fb9)

Blue is clickable area, orange is non-clickable margin
