### PR TITLE
Fix broken link to schematic file format page

### DIFF
--- a/content/for-creators/schematic.md
+++ b/content/for-creators/schematic.md
@@ -32,7 +32,7 @@ Functions that use schematics are passed a schematic specifier. A specifier can 
 
 ## Schematic file
 
-The MTS file format specifies a Luanti schematic in binary format. For information about the format see [Luanti Schematic File Format](/about/luanti-schematic-file-format/).
+The MTS file format specifies a Luanti schematic in binary format. For information about the format see [Luanti Schematic File Format](/for-creators/luanti-schematic-file-format/).
 
 The [Schematic Editor](https://content.luanti.org/packages/Wuzzy/schemedit/) mod allows you to conveniently export and import MTS schematic files without leaving the engine. The engine also has support for creating schematics through the Lua API with [core.create_schematic](https://api.luanti.org/core-namespace-reference/#schematics).
 


### PR DESCRIPTION
I was reading the schematic documentation page (https://docs.luanti.org/for-creators/schematic/) and got interested in the file format. But I was stopped by a broken link (https://docs.luanti.org/about/luanti-schematic-file-format/). Slightly disappointed that I couldn't learn more about the format, I googled the page title and found the real page (https://docs.luanti.org/for-creators/luanti-schematic-file-format/). So I'm here to fix the link for future readers! :)