### PR TITLE
Demote spellcheck to advisory step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
         run: git diff
       - name: Build site to check for errors
         run: npm run build:ci
+      - name: Spell check (advisory)
+        run: npm run test:spelling
+        continue-on-error: true
       - name: check that links are all valid
         uses: JustinBeckwith/linkinator-action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "hugo",
-    "build:ci": "hugo --panicOnWarning && npm run test:spelling && npm run test:format",
+    "build:ci": "hugo --panicOnWarning && npm run test:format",
     "clean": "rm -rf public && echo Clear browser cache as well!",
     "format": "sort-package-json && prettier --write .",
     "prepare": "git submodule init && git submodule update",


### PR DESCRIPTION
CI is failing due to spellcheck again, again on false positives ("SSIM" and "downscaling", introduced by https://github.com/luanti-org/docs.luanti.org/commit/915baa150a4e485ae3316c688d56ad066d9b06c1).

I think it's important that edits can be made by core devs and docs members without a ceremony so this keeps spellcheck, but makes it advisory, meaning if someone finds it useful on their PRs they can still check its output, but it doesn't bother everyone with hard CI failures.

Disclosure: AI was used for this (in hindsight probably unnecessarily)